### PR TITLE
修复匠魂模块部分残留问题

### DIFF
--- a/src/main/resources/data/avaritia_integration/recipes/common/blaze_cube/block_melting.json
+++ b/src/main/resources/data/avaritia_integration/recipes/common/blaze_cube/block_melting.json
@@ -11,6 +11,6 @@
     "fluid": "avaritia_integration:molten_blaze",
     "amount": 900
   },
-  "temperature": 3000,
+  "temperature": 1500,
   "time": 241
 }

--- a/src/main/resources/data/avaritia_integration/tinkering/materials/stats/blaze_cube.json
+++ b/src/main/resources/data/avaritia_integration/tinkering/materials/stats/blaze_cube.json
@@ -1,7 +1,6 @@
 {
   "stats": {
     "tconstruct:binding": {},
-    "tconstruct:maille": {},
     "tconstruct:handle": {
       "durability": -0.15,
       "mining_speed": 0.15,

--- a/src/main/resources/data/avaritia_integration/tinkering/materials/stats/crystal_matrix.json
+++ b/src/main/resources/data/avaritia_integration/tinkering/materials/stats/crystal_matrix.json
@@ -1,7 +1,6 @@
 {
   "stats": {
     "tconstruct:binding": {},
-    "tconstruct:maille": {},
     "tconstruct:handle": {
       "durability": 0.2,
       "mining_speed": 0.25,

--- a/src/main/resources/data/avaritia_integration/tinkering/materials/stats/neutronium.json
+++ b/src/main/resources/data/avaritia_integration/tinkering/materials/stats/neutronium.json
@@ -1,7 +1,6 @@
 {
   "stats": {
     "tconstruct:binding": {},
-    "tconstruct:maille": {},
     "tconstruct:handle": {
       "durability": 0.35,
       "mining_speed": 0.15,

--- a/src/main/resources/data/avaritia_integration/tinkering/modifiers/infinitum.json
+++ b/src/main/resources/data/avaritia_integration/tinkering/modifiers/infinitum.json
@@ -15,6 +15,11 @@
     {
       "type": "tconstruct:reduce_tool_damage",
       "flat": 1.0
+    },
+    {
+      "type": "tconstruct:modifier_slot",
+      "each_level": 1,
+      "name": "abilities"
     }
   ],
   "tooltip_display": "always"

--- a/src/main/resources/data/tconstruct/tinkering/tags/materials/book/blazing_blood.json
+++ b/src/main/resources/data/tconstruct/tinkering/tags/materials/book/blazing_blood.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+     "avaritia_integration:blaze_cube",
+     "avaritia_integration:crystal_matrix"
+  ]
+}

--- a/src/main/resources/data/tconstruct/tinkering/tags/materials/book/distant.json
+++ b/src/main/resources/data/tconstruct/tinkering/tags/materials/book/distant.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+     "avaritia_integration:infinity",
+     "avaritia_integration:neutronium"
+  ]
+}


### PR DESCRIPTION
修复部分材料可以用于制作锁链基底的问题
修复了材料没有出现在4级手册中的问题
修复了永恒的“能力槽+1”未生效的问题