### PR TITLE
feat(enderio): add new capacitors, optimize classes, and fix lang files

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/AICapacitorDef.java
+++ b/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/AICapacitorDef.java
@@ -1,0 +1,21 @@
+package committee.nova.mods.avaritia_integration.module.enderio;
+
+import committee.nova.mods.avaritia.init.registry.ModRarities;
+import net.minecraft.world.item.Rarity;
+
+public enum AICapacitorDef {
+    BLAZE_CUBE("blaze_cube_capacitor", 5.0f, ModRarities.EPIC),
+    CRYSTAL_MATRIX("crystal_matrix_capacitor", 7.0f, ModRarities.EPIC),
+    NEUTRONIUM("neutron_capacitor", 8.0f, ModRarities.LEGEND),
+    INFINITY("infinity_capacitor", 10.0f, ModRarities.COSMIC);
+
+    public final String id;
+    public final float baseLevel;
+    public final Rarity rarity;
+
+    AICapacitorDef(String id, float baseLevel, Rarity rarity) {
+        this.id = id;
+        this.baseLevel = baseLevel;
+        this.rarity = rarity;
+    }
+}

--- a/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/EnderIOModule.java
+++ b/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/EnderIOModule.java
@@ -18,7 +18,10 @@ public final class EnderIOModule implements Module {
 
     @Override
     public void collectCreativeTabItems(CreativeModeTab.ItemDisplayParameters parameters, CreativeModeTab.Output output) {
-        output.accept(EnderIOIntegrationItems.INFINITY_CAPACITOR.get());
+        for (AICapacitorDef def : AICapacitorDef.values()) {
+            output.accept(EnderIOIntegrationItems.CAPACITORS.get(def).get());
+        }
+
         output.accept(EnderIOIntegrationItems.INFINITY_GRINDING_BALL.get());
         output.accept(EnderIOIntegrationItems.NEUTRON_GRINDING_BALL.get());
     }

--- a/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/data/AICapacitorData.java
+++ b/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/data/AICapacitorData.java
@@ -9,15 +9,16 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
-public class InfinityCapacitorData implements ICapacitorData, INBTSerializable<Tag> {
-    public static final InfinityCapacitorData INSTANCE = new InfinityCapacitorData();
+public class AICapacitorData implements ICapacitorData, INBTSerializable<Tag> {
+    private final float baseLevel;
 
-    private InfinityCapacitorData() {
+    public AICapacitorData(float baseLevel) {
+        this.baseLevel = baseLevel;
     }
 
     @Override
     public float getBase() {
-        return 10;
+        return this.baseLevel;
     }
 
     @Override
@@ -37,6 +38,5 @@ public class InfinityCapacitorData implements ICapacitorData, INBTSerializable<T
 
     @Override
     public void deserializeNBT(Tag nbt) {
-        // We use fixed value so don't need to modify it.
     }
 }

--- a/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/item/AICapacitorItem.java
+++ b/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/item/AICapacitorItem.java
@@ -8,18 +8,19 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.util.LazyOptional;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class InfinityCapacitorItem extends Item implements IMultiCapabilityItem {
+public class AICapacitorItem extends Item implements IMultiCapabilityItem {
     private final ICapacitorData data;
 
-    public InfinityCapacitorItem(ICapacitorData data, Properties properties) {
+    public AICapacitorItem(ICapacitorData data, Properties properties) {
         super(properties);
         this.data = data;
     }
 
     @Override
-    public @Nullable MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
+    public @Nullable MultiCapabilityProvider initCapabilities(@NotNull ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
         provider.add(EIOCapabilities.CAPACITOR, LazyOptional.of(() -> this.data));
         return provider;
     }

--- a/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/registry/EnderIOIntegrationItems.java
+++ b/src/main/java/committee/nova/mods/avaritia_integration/module/enderio/registry/EnderIOIntegrationItems.java
@@ -3,19 +3,32 @@ package committee.nova.mods.avaritia_integration.module.enderio.registry;
 import committee.nova.mods.avaritia.api.common.item.BaseItem;
 import committee.nova.mods.avaritia.init.registry.ModRarities;
 import committee.nova.mods.avaritia_integration.AvaritiaIntegration;
-import committee.nova.mods.avaritia_integration.module.enderio.data.InfinityCapacitorData;
-import committee.nova.mods.avaritia_integration.module.enderio.item.InfinityCapacitorItem;
+import committee.nova.mods.avaritia_integration.module.enderio.AICapacitorDef;
+import committee.nova.mods.avaritia_integration.module.enderio.data.AICapacitorData;
+import committee.nova.mods.avaritia_integration.module.enderio.item.AICapacitorItem;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public final class EnderIOIntegrationItems {
     public static final DeferredRegister<Item> REGISTRY = DeferredRegister.create(Registries.ITEM, AvaritiaIntegration.MOD_ID);
 
-    public static final RegistryObject<Item> INFINITY_CAPACITOR = register("infinity_capacitor", () -> new InfinityCapacitorItem(InfinityCapacitorData.INSTANCE, new Item.Properties().rarity(ModRarities.EPIC)));
+    public static final Map<AICapacitorDef, RegistryObject<Item>> CAPACITORS = new EnumMap<>(AICapacitorDef.class);
+
+    static {
+        for (AICapacitorDef def : AICapacitorDef.values()) {
+            CAPACITORS.put(def, register(def.id, () -> new AICapacitorItem(
+                    new AICapacitorData(def.baseLevel),
+                    new Item.Properties().rarity(def.rarity)
+            )));
+        }
+    }
+
     public static final RegistryObject<Item> INFINITY_GRINDING_BALL = register("infinity_grinding_ball", () -> new BaseItem(pro -> pro.rarity(ModRarities.EPIC)));
     public static final RegistryObject<Item> NEUTRON_GRINDING_BALL = register("neutron_grinding_ball", () -> new BaseItem(pro -> pro.rarity(ModRarities.RARE)));
 

--- a/src/main/resources/assets/avaritia_integration/lang/en_us.json
+++ b/src/main/resources/assets/avaritia_integration/lang/en_us.json
@@ -63,6 +63,9 @@
 
   "item.avaritia_integration.blood_orb_of_armok": "Blood Orb of Armok",
 
+  "item.avaritia_integration.blaze_cube_capacitor": "Blaze Cube Capacitor",
+  "item.avaritia_integration.crystal_matrix_capacitor": "Crystal Matrix Capacitor",
+  "item.avaritia_integration.neutron_capacitor": "Neutron Capacitor",
   "item.avaritia_integration.infinity_capacitor": "Infinity Capacitor",
   "item.avaritia_integration.infinity_grinding_ball": "Infinity Grinding Ball",
   "item.avaritia_integration.neutron_grinding_ball": "Neutron Grinding Ball",
@@ -156,7 +159,6 @@
   "item.avaritia_integration.ignis_cake_base": "Ignis Cake Base",
   "item.avaritia_integration.star_cake": "Star Cake",
   "item.avaritia_integration.star_cake_base": "Star Cake Base",
-  "block.avaritia_integration.crystal_matrix_casing": "Crystal Matrix Casing",
   "block.avaritia_integration.extreme_basin": "Extreme Basin",
   "block.avaritia_integration.extreme_blaze_burner": "Extreme Blaze Burner",
   "block.avaritia_integration.extreme_crushing_wheel": "Extreme Crushing Wheel",

--- a/src/main/resources/assets/avaritia_integration/lang/zh_cn.json
+++ b/src/main/resources/assets/avaritia_integration/lang/zh_cn.json
@@ -62,12 +62,15 @@
 
   "item.avaritia_integration.blood_orb_of_armok": "阿尔莫克之血宝珠",
 
+  "item.avaritia_integration.blaze_cube_capacitor": "炽骨立方电容",
+  "item.avaritia_integration.crystal_matrix_capacitor": "水晶矩阵电容",
+  "item.avaritia_integration.neutron_capacitor": "中子电容",
   "item.avaritia_integration.infinity_capacitor": "无尽电容",
   "item.avaritia_integration.infinity_grinding_ball": "无尽磨珠",
   "item.avaritia_integration.neutron_grinding_ball": "中子磨珠",
 
-  "item.avaritia_integration.infinity_energy_tablet": "无尽能量版",
-  "item.avaritia_integration.neutron_energy_tablet": "中子能量版",
+  "item.avaritia_integration.infinity_energy_tablet": "无尽能量板",
+  "item.avaritia_integration.neutron_energy_tablet": "中子能量板",
   "item.avaritia_integration.infinity_control_circuit": "永恒无尽控制电路",
   "item.avaritia_integration.neutron_control_circuit": "中子辐射控制电路",
   "item.avaritia_integration.alloy_infinity": "无尽合金",
@@ -150,7 +153,6 @@
   "item.avaritia_integration.ignis_cake_base": "熔火蛋糕胚",
   "item.avaritia_integration.star_cake": "恒星蛋糕",
   "item.avaritia_integration.star_cake_base": "恒星蛋糕胚",
-  "block.avaritia_integration.crystal_matrix_casing": "水晶矩阵机壳",
   "block.avaritia_integration.extreme_basin": "超限工作盆",
   "block.avaritia_integration.extreme_blaze_burner": "终焉燃烧室",
   "block.avaritia_integration.extreme_crushing_wheel": "终极粉碎轮",


### PR DESCRIPTION
- Added Blazing Crystal Capacitor, Crystal Matrix Capacitor, and Neutronium Capacitor (textures and recipes are currently missing).
- Optimized the structure of capacitor classes.
- Added localization for the new capacitors in en_us.json and zh_cn.json.
- Fixed typos in zh_cn.json ("无尽能量版" to "无尽能量板", "中子能量版" to "中子能量板").
- Removed duplicate keys in both en_us.json and zh_cn.json (e.g., "block.avaritia_integration.crystal_matrix_casing").

---

- 新增了炽骨立方电容、水晶矩阵电容和中子态素电容（目前暂缺贴图和配方）。
- 优化并重构了电容类的代码结构。
- 在 en_us.json 和 zh_cn.json 语言包中补充了上述新增电容的本地化文本。
- 修复了 zh_cn.json 中遗留的错别字：将“无尽能量版”修正为“无尽能量板”，将“中子能量版”修正为“中子能量板”。
- 清理了中英文语言包中存在的重复键值（移除了多余的 "block.avaritia_integration.crystal_matrix_casing"）。